### PR TITLE
Fix emacs native compilation warning

### DIFF
--- a/bind-map.el
+++ b/bind-map.el
@@ -128,14 +128,13 @@
   :group 'bind-map
   :type  'string)
 
+(define-obsolete-variable-alias 'bind-map-local-bindings
+                                'bind-map-evil-local-bindings "2015-12-2")
 (defvar bind-map-evil-local-bindings '()
   "Each element takes the form (OVERRIDE-MODE STATE KEY DEF) and
 corresponds to a binding for an evil local state map.
 OVERRIDE-MODE is the minor mode that must be enabled for these to
 be activated.")
-(defvaralias 'bind-map-local-bindings 'bind-map-evil-local-bindings)
-(make-obsolete-variable 'bind-map-local-bindings
-                        'bind-map-evil-local-bindings "2015-12-2")
 
 (defun bind-map-put-map-properties (map-sym &rest properties)
   "Use put to add symbol properties to MAP-SYM."


### PR DESCRIPTION
```
Warning (comp): bind-map.el:138:40: Warning: Alias for
‘bind-map-evil-local-bindings’ should be declared before its referent
```

Apparently you're supposed to define the obsolete alias before the actual variable. I've seen it used this way in the emacs codebase and in other packages.

To reproduce, have emacs build with native compilation and notice the compilation logs. You can then open this file and run `M-x emacs-lisp-native-compile-and-load` before and after the changes to see the warning is removed.