### PR TITLE
Emergency PR: Avoid breakage on emacs < 29.1

### DIFF
--- a/bind-map.el
+++ b/bind-map.el
@@ -215,12 +215,16 @@ If both are nil, just return `mode'. If
 `bind-map-use-remapped-modes' is non-nil, also return mode to
 which it has been remapped in `major-mode-remap-alist' (if
 applicable). If `bind-map-use-aliased-modes' is non-nil, also
-return any modes for which `mode' is an alias (if applicable)."
+return any modes for which `mode' is an alias (if applicable).
+Note: finding aliased modes relies on `function-alias-p', which
+is only available on Emacs 29.1+."
   (let ((r-mode
          (or (and bind-map-use-remapped-modes
                   (boundp 'major-mode-remap-alist)
                   (alist-get mode major-mode-remap-alist))))
-        (a-modes (and bind-map-use-aliased-modes (function-alias-p mode))))
+        (a-modes (and bind-map-use-aliased-modes
+                      (fboundp 'function-alias-p)
+                      (function-alias-p mode))))
     (delq nil (append (list mode r-mode) a-modes))))
 
 (defun bind-map-add-to-major-mode-list (activate-var major-mode-list)


### PR DESCRIPTION
A [PR that I wrote](https://github.com/justbur/emacs-bind-map/pull/9#ref-issue-2175423956) was recently merged, but has [caused problems](https://github.com/syl20bnr/spacemacs/issues/16305) for anyone using `bind-map` with emacs < 29.1. 

The problem is in order to find aliased modes, I used `function-alias-p`, but this is *only* available in emacs 29.1+. As a result, anyone with emacs < 29.1 who is using the new version of emacs will get a cryptic error about `Symbol's function definition is void: function-alias-p`. My bad! :(

Handling aliased modes is important, because this is how AUCTeX remaps its modes in older versions of emacs (where `major-mode-remap-alist` is not available). However, while I/we try to add this functionality to `bind-map`, I wanted to fix my mistake and at least make `bind-map` work on older versions of emacs.

This PR just adds some logic to ensure that `function-alias-p` is available before trying to use it. If this looks cursorily good, I hope we can get it adopted ASAP so that it can make its way to MELPA.